### PR TITLE
chore: upgrade to zig version 0.15.1

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -194,13 +194,13 @@ test "fuzz" {
         // std.debug.print("{s}\n", .{buf});
         inline for (case_tags) |tocase| {
             if (tocase == .unknown) continue;
-            var rfbs = std.io.fixedBufferStream(buf);
-            var wfbs = std.io.fixedBufferStream(buf2);
+            var rfbs = std.Io.Reader.fixed(buf);
+            var wfbs = std.Io.Writer.fixed(buf2);
             const caseFn = @field(case, @tagName(tocase));
             if (comptime tocase.hasOptions())
-                try caseFn(rfbs.reader(), wfbs.writer(), .{})
+                try caseFn(&rfbs, &wfbs, .{})
             else
-                try caseFn(rfbs.reader(), wfbs.writer());
+                try caseFn(&rfbs, &wfbs);
             // std.debug.print("to-{s} '{s}'\n", .{ @tagName(tocase), wfbs.getWritten() });
         }
     }


### PR DESCRIPTION
This upgrades the project to be compatible with 0.15.1. Unfortunately, [Writergate](https://ziglang.org/download/0.15.1/release-notes.html#Writergate) and [There are too many ring buffer implementations in the standard library](https://github.com/ziglang/zig/issues/19231) hit this code base pretty hard. As a result, this commit is a bit large...sorry about that.

Here's a summary:

* Removed **all** anytype parameters from code, as they could all be replaced with `std.Io.Reader` and `std.Io.Writer`
* Switched to new methods, e.g. `readByte` => `takeByte`
* Removed LinearFifo usage, since that was [removed from the standard library](https://ziglang.org/download/0.15.1/release-notes.html#Ring-Buffers)

The last item may be a bit controversial. In several locations, the code was using a 2 byte ring buffer, which I thought would be more clearly expressed with just a current and next `u8` variable vs attempting to use the new `Io.Reader` and `Io.Writer` interface (which has the necessary ring buffer.

This PR passes all unit tests on 0.15.1, but I have not performed additional manual testing.